### PR TITLE
Moving functions: machine and customer files

### DIFF
--- a/include/machine.h
+++ b/include/machine.h
@@ -4,5 +4,6 @@
 #include <iostream>
 
 void welcome_menu();
-    
+int write_user_data(std::string first, std::string last, int acct_num, int pin);
+
 #endif

--- a/src/customer.cpp
+++ b/src/customer.cpp
@@ -24,8 +24,9 @@
     std::cout << "Your new account number is "<< acct_number << std::endl;
 
     std::cout << "Finally, we need to create a pin for your account" << std::endl;
-
-    return 0;
+    pin= create_pin();
+    
+    std::cout << "Your account set up has been completed, we will return you to the main menu" << std::endl;
  }
 
 int generate_account(){
@@ -40,27 +41,8 @@ int generate_account(){
     return acct_num;
 
 }
-
-
-int write_user_data(std::string first, std::string last, int acct_num, int pin){
-    //write customer data to txt file
-    // account number, first, last, balance, pin
-    std::ofstream outfile;
-
-    outfile.open("../data/accounts.txt", std::ios::app); // open file
-    if (outfile.is_open()) //confirm file opened
-    {
-        outfile << acct_num;
-        outfile.close();
-        
-    }
-    else
-        std::cerr << "Error writing to database";
-    
-}
-    
+   
 int create_pin(){
-    std::cout << "Welcome customer! Please create a pin for your new checking account." << std::endl;
     std::cout << "Pins must be a 4 digit number" << std::endl;
     std::cout << "Please enter your pin now:" << std::endl;
     

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -2,6 +2,7 @@
 #include "../include/transactions.h"
 
 #include <iostream>
+#include <fstream>
 
 void welcome_menu(){
     int selection;
@@ -36,4 +37,21 @@ void welcome_menu(){
 
     } while (selection <= 5);
 
+}
+
+int write_user_data(std::string first, std::string last, int acct_num, int pin){
+    //write customer data to txt file
+    // account number, first, last, balance, pin
+    std::ofstream outfile;
+
+    outfile.open("../data/accounts.txt", std::ios::app); // open file
+    if (outfile.is_open()) //confirm file opened
+    {
+        outfile << acct_num;
+        outfile.close();
+        
+    }
+    else
+        std::cerr << "Error writing to database";
+    
 }


### PR DESCRIPTION
Moved writing functions from customer to
machine. Anything related specifically
to actions taken by the machine should
stay in machine file for better reference
later.